### PR TITLE
Fix parseRADec regex

### DIFF
--- a/src/lib/stellarium_utils.ts
+++ b/src/lib/stellarium_utils.ts
@@ -18,7 +18,7 @@ export function parseStellariumData(text: string): ParsedStellariumData {
 
 function parseRADec(text: string) {
   let matches = text.match(
-    /RA\/Dec \(on date\): *([0-9hms.+°]+)\/([0-9.+°'"]+)/
+    /RA\/Dec \(on date\):\s*([0-9hms.+°'"-]+)\/([0-9.+°'"-]+)/
   );
   if (matches) {
     return { RA: matches[1], declination: matches[2] };


### PR DESCRIPTION
Fix the regex in the parseRADec function
as the previous was returning null from the Stellarium data text.